### PR TITLE
Update pagination.php

### DIFF
--- a/pagination.php
+++ b/pagination.php
@@ -3,18 +3,20 @@
 /* This Application Must Be Used With BootStrap 4 *  */
 $config['full_tag_open'] 	= '<div class="pagging text-center"><nav><ul class="pagination">';
 $config['full_tag_close'] 	= '</ul></nav></div>';
-$config['num_tag_open'] 	= '<li class="page-item"><span class="page-link">';
-$config['num_tag_close'] 	= '</span></li>';
+$config['num_tag_open'] 	= '<li class="page-item">';
+$config['num_tag_close'] 	= '</li>';
 $config['cur_tag_open'] 	= '<li class="page-item active"><span class="page-link">';
 $config['cur_tag_close'] 	= '<span class="sr-only">(current)</span></span></li>';
-$config['next_tag_open'] 	= '<li class="page-item"><span class="page-link">';
-$config['next_tagl_close'] 	= '<span aria-hidden="true">&raquo;</span></span></li>';
-$config['prev_tag_open'] 	= '<li class="page-item"><span class="page-link">';
-$config['prev_tagl_close'] 	= '</span></li>';
-$config['first_tag_open'] 	= '<li class="page-item"><span class="page-link">';
-$config['first_tagl_close'] = '</span></li>';
-$config['last_tag_open'] 	= '<li class="page-item"><span class="page-link">';
-$config['last_tagl_close'] 	= '</span></li>';
+$config['next_tag_open'] 	= '<li class="page-item">';
+$config['next_tagl_close'] 	= '<span aria-hidden="true">&raquo;</span></li>';
+$config['prev_tag_open'] 	= '<li class="page-item">';
+$config['prev_tagl_close'] 	= '</li>';
+$config['first_tag_open'] 	= '<li class="page-item">';
+$config['first_tagl_close'] = '</li>';
+$config['last_tag_open'] 	= '<li class="page-item">';
+$config['last_tagl_close'] 	= '</li>';
+
+$config['attributes'] = array('class' => 'page-link');
 
 // end of file Pagination.php 
 // Location config/pagination.php 


### PR DESCRIPTION
By setting $config['attributes'] like this, every anchor in the pagination will have the 'page-link' class added to itself. You only have to use the "<span class="page-link">" method on the "cur_tag_open" since the content is not a link.

The reason this way is better is due to the fact that the previous method rendered only the links clickable, not the whole 'page-item' button, besides it being less of a workaround. Using the previous method on the cur_tag is not a problem because none of it should be clickable anyway.